### PR TITLE
Fixing PropType on exportFile

### DIFF
--- a/download-link.es6
+++ b/download-link.es6
@@ -6,7 +6,7 @@ const DownloadLink = React.createClass({
     filename: React.PropTypes.string,
     label: React.PropTypes.string,
     style: React.PropTypes.object,
-    exportFile: React.PropTypes.function,
+    exportFile: React.PropTypes.func,
   },
 
   getDefaultProps() {

--- a/download-link.js
+++ b/download-link.js
@@ -18,7 +18,7 @@ var DownloadLink = _react2.default.createClass({
     filename: _react2.default.PropTypes.string,
     label: _react2.default.PropTypes.string,
     style: _react2.default.PropTypes.object,
-    exportFile: _react2.default.PropTypes.function
+    exportFile: _react2.default.PropTypes.func
   },
 
   getDefaultProps: function getDefaultProps() {


### PR DESCRIPTION
React v15 is throwing a warning in DEV mode because "function" is not a valid PropType. Changing it to "func" instead:
https://facebook.github.io/react/docs/typechecking-with-proptypes.html
