### PR TITLE
Remove javascript call from href attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,8 @@ var DownloadLink = function (_Component) {
       } else {
         magicDownload(text, this.props.filename);
       }
+
+      return false;
     }
   }, {
     key: "render",
@@ -71,7 +73,7 @@ var DownloadLink = function (_Component) {
       return _react2.default.createElement(this.props.tagName || "a", {
         style: this.props.style,
         className: this.props.className,
-        href: "javascript:void(0)",
+        href: "#",
         onClick: this.handleDownloadClick.bind(this)
       }, this.props.label);
     }

--- a/index.js
+++ b/index.js
@@ -36,6 +36,9 @@ var DownloadLink = function (_Component) {
     value: function handleDownloadClick(event) {
       var _this2 = this;
 
+      event.persist();
+      event.preventDefault();
+
       function magicDownload(text, fileName) {
         var blob = new Blob([text], {
           type: "text/csv;charset=utf8;"
@@ -64,8 +67,6 @@ var DownloadLink = function (_Component) {
       } else {
         magicDownload(text, this.props.filename);
       }
-
-      return false;
     }
   }, {
     key: "render",

--- a/index.mjs
+++ b/index.mjs
@@ -3,6 +3,9 @@ import PropTypes from "prop-types";
 
 class DownloadLink extends Component {
   handleDownloadClick(event) {
+    event.persist();
+    event.preventDefault();
+
     function magicDownload(text, fileName) {
       const blob = new Blob([text], {
         type: "text/csv;charset=utf8;"
@@ -29,8 +32,6 @@ class DownloadLink extends Component {
     } else {
       magicDownload(text, this.props.filename);
     }
-
-    return false;
   }
 
   render() {

--- a/index.mjs
+++ b/index.mjs
@@ -29,6 +29,8 @@ class DownloadLink extends Component {
     } else {
       magicDownload(text, this.props.filename);
     }
+
+    return false;
   }
 
   render() {
@@ -37,7 +39,7 @@ class DownloadLink extends Component {
       {
         style: this.props.style,
         className: this.props.className,
-        href: "javascript:void(0)",
+        href: "#",
         onClick: this.handleDownloadClick.bind(this)
       },
       this.props.label


### PR DESCRIPTION
Hey Peter!

Thank you for the work, you have done here! In the console I got a little notification from react, that they will block hrefs with javascript calls inside of it.

This removes the javascript call from the href attribute.

See also here: https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-javascript-urls

Let me know, if I should change something.

Thanks!